### PR TITLE
Improve height handling

### DIFF
--- a/helpers/Helpers.py
+++ b/helpers/Helpers.py
@@ -1,4 +1,5 @@
-def imc(weight=0, height=0):
-    if weight and height:
-        return round((weight / (height ** 2)), 2)
+def imc(weight=0, height_cm=0):
+    if weight and height_cm:
+        height_m = height_cm / 100
+        return round((weight / (height_m ** 2)), 2)
     return 0

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ col1, col2 = st.columns(2)
 with col1:
     st.radio("Género", ("Masculino", "Femenino"), key="sex", horizontal=True)
     st.number_input("Edad", key="age")
-    st.number_input("Perimetro abdominal (medido a nivel del ombligo) :", key="perimeter")
+    st.number_input("Perimetro abdominal en Cm (medido a nivel del ombligo) :", key="perimeter")
 
 with col2:
     st.number_input("Peso en Kg", key="weight")

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ with col1:
 
 with col2:
     st.number_input("Peso en Kg", key="weight")
-    st.number_input("Altura en m2", key="height")
+    st.number_input("Altura en Cm", key="height")
     st.markdown(f"### **IMC:** {imc(st.session_state.get('weight'), st.session_state.get('height'))}")
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,7 +5,7 @@ import unittest
 class TestHelpers(unittest.TestCase):
     def test_imc(self):
         test_imc = [
-            {'weight': 104, 'height': 1.75, 'result': 33.96},
+            {'weight': 104, 'height': 175, 'result': 33.96},
             {'weight': 0, 'height': 0, 'result': 0}
         ]
 


### PR DESCRIPTION
En este pull request se ajusta cómo se solicita la altura del usuario en el formulario. Antes, se pedía la altura en "metros cuadrados", pero el algoritmo espera la altura en metros y luego aplica el cuadrado al valor ingresado. Este cambio asegura que la entrada sea consistente con lo que el algoritmo necesita.

También se sugiere cambiar la unidad de entrada a centímetros. Esto ayuda a mantener la coherencia con el sistema métrico, donde el peso ya se registra en kilogramos (Kg). Esta modificación busca hacer que el ingreso de datos sea más intuitivo y evitar posibles confusiones para los usuarios.

Buen trabajo @parrotsoft 😎